### PR TITLE
Add overload for InitializeService with callback parameter

### DIFF
--- a/SignalGo.Server/ServiceManager/ServerBase.cs
+++ b/SignalGo.Server/ServiceManager/ServerBase.cs
@@ -31,6 +31,8 @@ namespace SignalGo.Server.ServiceManager
 {
     public abstract class ServerBase : IDisposable
     {
+        private Func<object> _serviceCreator;
+
         /// <summary>
         /// calling method count if this is going to zero server can stop
         /// </summary>
@@ -187,6 +189,12 @@ namespace SignalGo.Server.ServiceManager
         public void InitializeService<T>()
         {
             InitializeService(typeof(T));
+        }
+
+        public void InitializeService<T>(Func<object> serviceCreator)
+        {
+            _serviceCreator = serviceCreator;
+            InitializeService<T>();
         }
 
         internal object FindClientServiceByType(ClientInfo client, Type serviceType)
@@ -1555,7 +1563,9 @@ namespace SignalGo.Server.ServiceManager
                 {
                     throw new Exception($"{client.IPAddress} {client.SessionId} this service for this client exist, type: {serviceType.FullName} : serviceName:{callInfo.ServiceName}");
                 }
-                var objectInstance = Activator.CreateInstance(serviceType);//
+                
+                var objectInstance = _serviceCreator == null ? Activator.CreateInstance(serviceType) : _serviceCreator();
+
                 //objectInstance.CurrentClient = client;
                 //objectInstance.ServerBase = this;
                 this.Services[client].Add(objectInstance);


### PR DESCRIPTION
Add callback to allow user to control creation of the service object (makes it easy to add any state to each service object). It's hard to tell from the code if other Activator.CreateInstance calls should be updated or not. I'll probably also create a similar PR for the client side.